### PR TITLE
🐛 Fix the `GetAnimeList` method that returned only the first 300 anime.

### DIFF
--- a/AnimeList.go
+++ b/AnimeList.go
@@ -1,14 +1,12 @@
 package mal
 
 import (
-	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
-
-	"github.com/PuerkitoBio/goquery"
+	"time"
 
 	"github.com/aerogo/http/client"
 )
@@ -17,11 +15,12 @@ import (
 type AnimeList []*AnimeListItem
 
 // GetAnimeList returns the user's anime list.
-func GetAnimeList(userName string) (AnimeList, error) {
+func getAnimeList(userName string, page int) (AnimeList, error) {
 	animeList := AnimeList{}
 
+	offset := page * 300
 	// Fetch the page
-	response, err := client.Get("https://myanimelist.net/animelist/" + userName + "?status=7").End()
+	response, err := client.Get("https://myanimelist.net/animelist/" + userName + "/load.json?offset=" + strconv.Itoa(offset) + "&status=7").End()
 
 	if err != nil {
 		return nil, err
@@ -30,31 +29,49 @@ func GetAnimeList(userName string) (AnimeList, error) {
 	if response.StatusCode() != http.StatusOK {
 		return nil, fmt.Errorf("Status code: %d", response.StatusCode())
 	}
-
 	// Parse the HTML
-	reader := bytes.NewReader(response.Bytes())
-	document, err := goquery.NewDocumentFromReader(reader)
 
 	if err != nil {
 		return nil, err
 	}
 
-	dataItems, exists := document.Find(".list-table").First().Attr("data-items")
-
-	if !exists {
-		return nil, errors.New("Missing data-items attribute")
-	}
-
+	var dataItems = response.String()
 	// Fix is_rewatching field
 	dataItems = strings.Replace(dataItems, `"is_rewatching":""`, `"is_rewatching":false`, -1)
 	dataItems = strings.Replace(dataItems, `"is_rewatching":0`, `"is_rewatching":false`, -1)
 	dataItems = strings.Replace(dataItems, `"is_rewatching":1`, `"is_rewatching":true`, -1)
-
 	// Parse JSON
 	err = json.Unmarshal([]byte(dataItems), &animeList)
 
 	if err != nil {
 		return nil, err
+	}
+
+	return animeList, nil
+}
+
+func GetAnimeList(userName string) (AnimeList, error) {
+	animeList := AnimeList{}
+	page := 0
+	ticker := time.NewTicker(500 * time.Millisecond)
+	rateLimit := ticker.C
+	defer ticker.Stop()
+
+	for {
+		nextAnimeList, err := getAnimeList(userName, page)
+
+		if err != nil {
+			return nil, err
+		}
+
+		if len(nextAnimeList) == 0 {
+			break
+		}
+
+		animeList = append(animeList, nextAnimeList...)
+		page++
+		// Wait for rate limiter to allow the next request
+		<-rateLimit
 	}
 
 	return animeList, nil

--- a/AnimeList.go
+++ b/AnimeList.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
@@ -19,8 +18,10 @@ func getAnimeList(userName string, page int) (AnimeList, error) {
 	animeList := AnimeList{}
 
 	offset := page * 300
+
 	// Fetch the page
-	response, err := client.Get("https://myanimelist.net/animelist/" + userName + "/load.json?offset=" + strconv.Itoa(offset) + "&status=7").End()
+	url := fmt.Sprintf("https://myanimelist.net/animelist/%s/load.json?offset=%d&status=7", userName, offset)
+	response, err := client.Get(url).End()
 
 	if err != nil {
 		return nil, err
@@ -35,7 +36,8 @@ func getAnimeList(userName string, page int) (AnimeList, error) {
 		return nil, err
 	}
 
-	var dataItems = response.String()
+	dataItems := response.String()
+
 	// Fix is_rewatching field
 	dataItems = strings.Replace(dataItems, `"is_rewatching":""`, `"is_rewatching":false`, -1)
 	dataItems = strings.Replace(dataItems, `"is_rewatching":0`, `"is_rewatching":false`, -1)
@@ -53,7 +55,7 @@ func getAnimeList(userName string, page int) (AnimeList, error) {
 func GetAnimeList(userName string) (AnimeList, error) {
 	animeList := AnimeList{}
 	page := 0
-	ticker := time.NewTicker(500 * time.Millisecond)
+	ticker := time.NewTicker(1100 * time.Millisecond)
 	rateLimit := ticker.C
 	defer ticker.Stop()
 

--- a/MAL_test.go
+++ b/MAL_test.go
@@ -11,6 +11,7 @@ func TestAnimeList(t *testing.T) {
 		"Aky",
 		"soory",
 		"Subpyro",
+		"PaladinRaid",
 	}
 
 	for _, userName := range userNames {


### PR DESCRIPTION
This PR aims to fix the bug reported on the [forum](https://notify.moe/thread/CUERVdUmR).

I changed the URL to add the offset used by mal to get the next anime via a paging system, and I've also added the user who pointed out the issue in the test.
I added a rate limit for the request since I got the status code **429** (Too Many Requests) from **MAL** in the test so we can expect to get it if the user has a considerable list.

The problem I see with this solution is that requesting https://notify.moe/import/myanimelist/animelist for **PaladinRaid** was initially taking _~1400ms_ and now it's taking _~4300ms_ which is a lot of time in my opinion.